### PR TITLE
Prevent installing README.pod to INC

### DIFF
--- a/INSTALL.SKIP
+++ b/INSTALL.SKIP
@@ -1,0 +1,1 @@
+README\.pod$

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Changes
+INSTALL.SKIP
 lib/RedisDB/Parser.pm
 lib/RedisDB/Parser/Error.pm
 lib/RedisDB/Parser/PP.pm


### PR DESCRIPTION
Unfortunately, ".pod" extensions are treated the same as top-level
'.pl' and '.pm' extensions and installed to @INC under the packages
prefix directory.

This avoids this problem by filtering out the .pod file in the blib/
to DESTDIR install stage.